### PR TITLE
Add Embed Builder

### DIFF
--- a/src/lib/utils/Embeds.ts
+++ b/src/lib/utils/Embeds.ts
@@ -49,6 +49,7 @@ class BaseEmbed {
 
     // Color
     if (this.options.color) embed.setColor(this.options.color);
+    else embed.setColor(this.color);
 
     // Description
     if (this.options.description)

--- a/src/lib/utils/Embeds.ts
+++ b/src/lib/utils/Embeds.ts
@@ -1,0 +1,100 @@
+import {
+  EmbedField,
+  MessageEmbed,
+  ColorResolvable,
+  MessageAttachment,
+  FileOptions
+} from "discord.js";
+
+export interface IEmbedOptions {
+  fields?: EmbedField[];
+  author?: {
+    name: string;
+    url?: string;
+    iconURL?: string;
+  };
+  description?: string;
+  files?: (MessageAttachment | string | FileOptions)[];
+  footer?: { text?: string; iconURL?: string; proxyIconURL?: string };
+  image?: string;
+  provider?: { name: string; url: string };
+  thumbnail?: string;
+  timestamp?: number | Date;
+  title?: string;
+  url?: string;
+}
+
+class BaseEmbed {
+  public constructor(
+    protected color: ColorResolvable,
+    protected options: IEmbedOptions
+  ) {}
+
+  public create(): MessageEmbed {
+    // Create Embed and add color
+    const embed = new MessageEmbed().setColor(this.color);
+    this.setOptions(embed);
+    return embed;
+  }
+
+  public setOptions(embed: MessageEmbed): MessageEmbed {
+    // Author
+    if (this.options.author)
+      embed.setAuthor(
+        this.options.author.name,
+        this.options.author.iconURL,
+        this.options.author.url
+      );
+
+    // Description
+    if (this.options.description)
+      embed.setDescription(this.options.description);
+
+    // Fields
+    if (this.options.fields) {
+      for (const field of this.options.fields)
+        embed.addField(field.name, field.value, field.inline);
+    }
+
+    // Files
+    if (this.options.files) embed.attachFiles(this.options.files);
+
+    // Footer
+    if (this.options.footer) embed.setFooter(this.options.footer);
+
+    // Image
+    if (this.options.image) embed.setImage(this.options.image);
+
+    // Thumbnail
+    if (this.options.thumbnail) embed.setThumbnail(this.options.thumbnail);
+
+    // Timestamp
+    if (this.options.timestamp) embed.setTimestamp(this.options.timestamp);
+
+    // Title
+    if (this.options.title) embed.setTitle(this.options.title);
+
+    // URL
+    if (this.options.url) embed.setURL(this.options.url);
+
+    return embed;
+  }
+}
+
+export class InformationEmbed extends BaseEmbed {
+  public constructor(options: IEmbedOptions) {
+    super("#2196f3", options);
+  }
+}
+
+export class SuccessEmbed extends BaseEmbed {
+  public constructor(options: IEmbedOptions) {
+    super("#8bc34a", options);
+  }
+}
+
+export class ErrorEmbed extends BaseEmbed {
+  public constructor(options: IEmbedOptions) {
+    super("#f44336", options);
+  }
+}

--- a/src/lib/utils/Embeds.ts
+++ b/src/lib/utils/Embeds.ts
@@ -7,13 +7,14 @@ import {
 } from "discord.js";
 
 export interface IEmbedOptions {
-  fields?: EmbedField[];
   author?: {
     name: string;
     url?: string;
     iconURL?: string;
   };
+  color?: ColorResolvable;
   description?: string;
+  fields?: EmbedField[];
   files?: (MessageAttachment | string | FileOptions)[];
   footer?: { text?: string; iconURL?: string; proxyIconURL?: string };
   image?: string;
@@ -45,6 +46,9 @@ class BaseEmbed {
         this.options.author.iconURL,
         this.options.author.url
       );
+
+    // Color
+    if (this.options.color) embed.setColor(this.options.color);
 
     // Description
     if (this.options.description)


### PR DESCRIPTION
- Create Embeds with `.create()`,
- Set Options of current embeds with `.setOptions(embed)`

Only one of these is needed.

Example
```TypeScript
// Creates a new Embed with specified fields of specified type
const embed = new SuccessEmbed({ title: "Pinged B1nzy", description: "Banned user for pinging B1nzy" }).create();

// Updates embed with timestamp and keeps other fields, updates type to ErrorEmbed
new ErrorEmbed({ timestamp: new Date() }).setOptions(embed);
```